### PR TITLE
Split into lockBlocking and lockNonBlocking

### DIFF
--- a/Test/Case/Model/Behavior/LockableBehaviorTest.php
+++ b/Test/Case/Model/Behavior/LockableBehaviorTest.php
@@ -82,6 +82,42 @@ class LockableBehaviorTest extends CakeTestCase {
 		$this->assertTrue($this->Model->unlock(1));
 	}
 
+	public function testLockBlocking() {
+		// lockable
+		$this->assertTrue($this->Model->lockBlocking(1));
+		// now unlock
+		$this->assertTrue($this->Model->unlock(1));
+		// now we can re-lock
+		$this->assertTrue($this->Model->lockBlocking(1));
+		// now unlock (cleanup)
+		$this->assertTrue($this->Model->unlock(1));
+	}
+
+	public function testLockNonBlocking() {
+		// lockable
+		$this->assertTrue($this->Model->lockNonBlocking(1));
+		// now unlock
+		$this->assertTrue($this->Model->unlock(1));
+		// now we can re-lock
+		$this->assertTrue($this->Model->lockNonBlocking(1));
+		// now unlock (cleanup)
+		$this->assertTrue($this->Model->unlock(1));
+	}
+
+	public function testLockNonBlockingTimeout() {
+		$this->assertTrue($this->Model->lockNonBlocking(1));
+		$this->Model->rc();
+		// Wait 100000 microseconds / 100 milliseconds.
+		usleep(100000);
+		$this->Model->rc();
+		$this->assertFalse($this->Model->lockNonBlocking(1));
+		// Wait 1000000 microseconds / 1 seconds.
+		usleep(1000000);
+		$this->Model->rc();
+		$this->assertTrue($this->Model->lockNonBlocking(1));
+		// now unlock (cleanup)
+		$this->assertTrue($this->Model->unlock(1));
+	}
 
 	// Test that locking actually makes me wait if someone else has the lock.
 	/*


### PR DESCRIPTION
The `lock()` method signature remains unchanged (100% backwards compatible)

Split the functionality into a private `_lock()` method with a new parameter
  for `$blockingTimeout` (seconds)

Added two helper functions for `lockBlocking()` and `lockNonBlocking()`

Added some more unit tests, but still nothing that's fully reliable on
demonstrating the locking, because obtaining a new lock on the same database
connection closes down the previous lock :(

> If you have a lock obtained with GET_LOCK(), it is released when you execute
> RELEASE_LOCK(), execute a new GET_LOCK(), or your connection terminates (either
> normally or abnormally). Locks obtained with GET_LOCK() do not interact with
> transactions.
> 
> http://dev.mysql.com/doc/refman/5.0/en/miscellaneous-functions.html#function_get-lock
